### PR TITLE
fix: fail2ban silently skipped when ssh_hardening is disabled

### DIFF
--- a/fortress_improved.sh
+++ b/fortress_improved.sh
@@ -171,7 +171,7 @@ declare -A MODULE_DEPS=(
     ["usb_protection"]=""
     ["filesystems"]=""
     ["package_verification"]="system_update"
-    ["fail2ban"]="system_update firewall ssh_hardening"
+    ["fail2ban"]="system_update firewall"
 )
 
 #=============================================================================


### PR DESCRIPTION
Hey, great project.
Ran the script on a Debian 13 server where we kept password auth on — so `ssh_hardening` was disabled in the config. Even with `ENABLE_FAIL2BAN=true`, fail2ban got silently skipped. That's the opposite of what you want: password auth on, no brute-force protection.

Traced it to `MODULE_DEPS`: fail2ban lists `ssh_hardening` as a required dependency, so disabling one kills the other.

Looked at `module_fail2ban()` — it reads `/etc/ssh/sshd_config` directly to check whether password auth is active and decide which jails to configure. It doesn't use any state or output from `ssh_hardening`. The dependency isn't doing anything useful.

The README describes exactly this split: fail2ban is the protection layer for password-based setups, ssh_hardening is what you enable once you've moved to key-only auth. They're intended as alternatives for different phases of hardening, not as a chain.

Fix is a one-liner: drop `ssh_hardening` from fail2ban's dependency list.