### PR TITLE
fix: fail2ban jail config broken on modern Debian and multi-server setups

### DIFF
--- a/fortress_improved.sh
+++ b/fortress_improved.sh
@@ -1303,7 +1303,7 @@ module_fail2ban() {
     local has_web_server=false
     local has_mail_server=false
     local ssh_has_password_auth=true
-    
+
     command -v apache2 &>/dev/null && has_web_server=true
     command -v nginx &>/dev/null && has_web_server=true
     command -v postfix &>/dev/null && has_mail_server=true
@@ -1366,10 +1366,10 @@ action = ${f2b_action}
 [sshd]
 enabled = ${ssh_has_password_auth}
 port = ssh
-logpath = /var/log/auth.log
+backend = systemd
 EOF
 
-        if [[ "${has_web_server}" == "true" ]]; then
+        if command -v nginx &>/dev/null; then
             ${SUDO} tee -a /etc/fail2ban/jail.local > /dev/null << 'EOF'
 
 [nginx-http-auth]
@@ -1377,6 +1377,11 @@ enabled = true
 filter = nginx-http-auth
 port = http,https
 logpath = /var/log/nginx/error.log
+EOF
+        fi
+
+        if command -v apache2 &>/dev/null; then
+            ${SUDO} tee -a /etc/fail2ban/jail.local > /dev/null << 'EOF'
 
 [apache-auth]
 enabled = true


### PR DESCRIPTION
Two separate issues found while running the script on a Debian 13 server, both causing fail2ban to fail on startup.

**1. `/var/log/auth.log` doesn't exist on Debian 12+**

The sshd jail config had `logpath = /var/log/auth.log`. On Debian 12 and 13, systemd-journald handles auth logging and `/var/log/auth.log` is not created by default. fail2ban starts, can't find the log file, and exits.

Fixed by replacing `logpath` with `backend = systemd`, which reads SSH auth events directly from the systemd journal. Works on older Debian/Ubuntu too since the journal has always existed alongside auth.log — so this is strictly more portable.

**2. Both nginx and apache jails get written even if only one is installed**

The web server jails were written inside a single `if [[ "${has_web_server}" == "true" ]]` block. That flag is set to true if either nginx or apache2 is found. The result: on an nginx-only server, an apache jail pointing at `/var/log/apache*/*error.log` (which doesn't exist) gets written. fail2ban then refuses to start because it can't find the log path.

Fixed by splitting into two separate `command -v` checks — each jail is only written if its corresponding binary is actually present on the system.

Both issues were hit in practice on a Debian 13 machine with nginx and no Apache installed.